### PR TITLE
Add smaller alpine based image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ Base Docker images used for other Docker images.
 * Image with `ubuntu-trusty` tag is based on Ubuntu 14.04 LTS (Trusty)
 * Image with `ubuntu-xenial` tag is based on Ubuntu 16.04 LTS (Xenial)
 * Image with `ubuntu-bionic` tag is based on Ubuntu 18.04 LTS (Bionic)
+* Image with `alpine` tag is based on alpine 3.8
 
 It configures UTC as a container timezone.

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -1,9 +1,4 @@
 FROM alpine:3.8
 
-ENV DEBIAN_FRONTEND noninteractive
-
-# apt-utils seems missing and warnings are shown, so we install it.
 RUN apk update && \ 
- echo 'UTC' > /etc/timezone && \
- apk add tzdata file bash && \
- rm /etc/localtime
+ apk add sudo zdata file bash

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.8
 
 RUN apk update && \ 
+ echo 'UTC' > /etc/timezone && \
  apk add sudo zdata file bash

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.8
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# apt-utils seems missing and warnings are shown, so we install it.
+RUN apk update && \ 
+ echo 'UTC' > /etc/timezone && \
+ apk add tzdata file bash && \
+ rm /etc/localtime


### PR DESCRIPTION
I am not sure about what exactly was happening in the ubuntu based image, but I figured that alpine is by default set to UTC tz and there was no cron job setup which the other docker files try to delete.